### PR TITLE
Fixed the permission denied error on data files by moving them to /tmp

### DIFF
--- a/cartographer.py
+++ b/cartographer.py
@@ -18,6 +18,7 @@ import json
 import struct
 import numpy as np
 import copy
+import os
 from numpy.polynomial import Polynomial
 from . import manual_probe
 from . import probe
@@ -673,7 +674,7 @@ class CartographerProbe:
         else:
             f = None
             completion_cb = None
-            fn = gcmd.get("FILENAME")
+            fn = os.path.join("/tmp", gcmd.get("FILENAME"))
             f = open(fn, "w")
             def close_file():
                 f.close()

--- a/idm.py
+++ b/idm.py
@@ -19,6 +19,7 @@ import json
 import struct
 import numpy as np
 import copy
+import os
 from numpy.polynomial import Polynomial
 from . import manual_probe
 from . import probe
@@ -674,7 +675,7 @@ class IDMProbe:
         else:
             f = None
             completion_cb = None
-            fn = gcmd.get("FILENAME")
+            fn = os.path.join("/tmp", gcmd.get("FILENAME"))
             f = open(fn, "w")
             def close_file():
                 f.close()


### PR DESCRIPTION
Current code will produce a permission denied on most klipper installation during temperature differential calibration due to the script trying to write in klipper main directory.

The customary way of doing on-disk file write is to put them under /tmp. This patch does this.