### PR TITLE
Added option to use a different temperature sensor in case the thermistor on the probe gets broken

### DIFF
--- a/cartographer.py
+++ b/cartographer.py
@@ -43,6 +43,11 @@ class CartographerProbe:
         self.lift_speed = config.getfloat("lift_speed", self.speed, above=0.0)
         self.backlash_comp = config.getfloat("backlash_comp", 0.5)
 
+        if config.get("temp_sensor_override", None):
+            self.thermistor_override = config.printer.load_object(config, "temperature_sensor " + config.get("temp_sensor_override"))
+        else:
+            self.thermistor_override = None
+
         self.x_offset = config.getfloat("x_offset", 0.0)
         self.y_offset = config.getfloat("y_offset", 0.0)
 
@@ -468,8 +473,11 @@ class CartographerProbe:
         sample["time"] = self._mcu.clock_to_print_time(clock)
 
     def _enrich_sample_temp(self, sample):
-        temp_adc = sample["temp"] / self.temp_smooth_count * self.inv_adc_max
-        sample["temp"] = self.thermistor.calc_temp(temp_adc)
+        if self.thermistor_override is None:
+            temp_adc = sample["temp"] / self.temp_smooth_count * self.inv_adc_max
+            sample["temp"] = self.thermistor.calc_temp(temp_adc)
+        else:
+            sample["temp"], _ = self.thermistor_override.get_temp(sample["time"])
 
     def _enrich_sample_freq(self, sample):
         sample["data_smooth"] = self._data_filter.value()
@@ -553,6 +561,9 @@ class CartographerProbe:
                                 curtime + STREAM_TIMEOUT)
                         updated_timer = True
 
+                    # Have to enrich time before temp, because we rely on time
+                    # being set if we use an existing temperature_sensor
+                    self._enrich_sample_time(sample)
                     self._enrich_sample_temp(sample)
                     temp = sample["temp"]
                     if self.model_temp is not None and not (-40 < temp < 180):
@@ -567,7 +578,6 @@ class CartographerProbe:
                         self.measured_min = min(self.measured_min, temp)
                         self.measured_max = max(self.measured_max, temp)
 
-                    self._enrich_sample_time(sample)
                     self._data_filter.update(sample["time"], sample["data"])
                     self._enrich_sample_freq(sample)
 


### PR DESCRIPTION
Added a new optional parameter called `temp_sensor_override` which lets you specify an already configured temperature_sensor to use to poll current temperature.

I used this to configure it to my chamber temperature, assuming the temp of the coil would be fairly similar to the temperature in the chamber, but you can configure it to whatever temperature sensor you think is going to provide the best results.