### PR TITLE
Implement automatic release drafting

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,54 @@
+name-template: "Release v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+exclude-labels:
+  - "skip-changelog"
+categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - breaking-change
+  - title: "🚀 Features"
+    labels:
+      - feature
+  - title: "🐛 Bug Fixes"
+    labels:
+      - bug
+  - title: "🧰 Maintenance"
+    labels:
+      - chore
+autolabeler:
+  - label: "breaking-change"
+    body:
+      - "/breaking change/i"
+  - label: "feature"
+    branch:
+      - '/feature\/.+/'
+    title:
+      - "/feat/i"
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+    title:
+      - "/fix/i"
+  - label: "chore"
+    title:
+      - "/chore/"
+version-resolver:
+  major:
+    labels:
+      - "breaking-change"
+  minor:
+    labels:
+      - "feature"
+  patch:
+    labels:
+      - "bug"
+      - "chore"
+  default: patch
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          prerelease: true
+          prerelease-identifier: beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Should allow us to make better use of the moonraker update channel.
Currently only maintains one draft, as `release-drafter` does not seem to be able to differentiate.
I will look into adding that functionality in their application, but this should at least help us get started.

With this change we can ask our users to set `channel: beta` and it should automatically use the tag of the newest published release.
To target the users on `channel: stable` we would have to mark a release as not pre-release and "latest".
`channel: dev` will, as now, pull latest commit from master - we should move the general users away from this.

Example: https://github.com/Jomik/release-drafter-test/releases