### PR TITLE
feat: `MOVE` added to `CARTOGRAPHER_TOUCH`

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -437,7 +437,7 @@ class Scanner:
             retries = 0
             gcmd.respond_info("Initiating Touch Procedure...")
             
-            new_retry = 0
+            new_retry = False
             samples = []
             
             has_shown_retry_info = False  # Initialize the flag
@@ -448,7 +448,7 @@ class Scanner:
                         gcmd.respond_info(f"Retry Attempt {int(retries)}")
                         has_shown_retry_info = True  # Set flag to True after showing the message
                 
-                if randomize > 0 and new_retry == 1:
+                if randomize > 0 and new_retry:
                         # Generate random offsets within ±5 units for both x and y
                         x_offset = random.uniform(-randomize, randomize)
                         y_offset = random.uniform(-randomize, randomize)
@@ -461,7 +461,7 @@ class Scanner:
                                              
                         # Respond with the randomized movement info
                         gcmd.respond_info(f"Moving touch location slightly by (x: {x_offset:.2f}, y: {y_offset:.2f})")
-                        new_retry = 0
+                        new_retry = False
                         
                 self.toolhead.wait_moves()
                 self.set_accel(accel)
@@ -498,7 +498,7 @@ class Scanner:
                         raise gcmd.error(f"Exceeded maximum retries [{retries}/{int(max_retries)}]")
                     gcmd.respond_info(f"Deviation of {deviation:.4f} exceeds tolerance of {tolerance:.4f}, retrying...")
                     retries += 1
-                    new_retry = 1
+                    new_retry = True
                     samples.clear()
                     has_shown_retry_info = False  # Reset the flag for the next retry cycle
                 self.log_debug_info(verbose, gcmd, f"Deviation: {deviation:.4f}\nNew Average: {average:.4f}\nTolerance: {tolerance:.4f}")

--- a/scanner.py
+++ b/scanner.py
@@ -453,8 +453,6 @@ class Scanner:
                         x_offset = random.uniform(-randomize, randomize)
                         y_offset = random.uniform(-randomize, randomize)
                         
-                        cur_pos = self.toolhead.get_position()[:]
-                        
                         # Apply the random offset to your touch location (assume x, y are current coordinates)
                         initial_position[0] = initial_position[0] + x_offset
                         initial_position[1] = initial_position[1] + y_offset

--- a/scanner.py
+++ b/scanner.py
@@ -442,6 +442,10 @@ class Scanner:
             
             has_shown_retry_info = False  # Initialize the flag
             
+            original_position = initial_position[:]
+            x_min, x_max = original_position[0] - randomize, original_position[0] + randomize
+            y_min, y_max = original_position[1] - randomize, original_position[1] + randomize
+            
             while len(samples) < num_samples:
                 if retries > 0:
                     if not has_shown_retry_info:
@@ -453,14 +457,22 @@ class Scanner:
                         x_offset = random.uniform(-randomize, randomize)
                         y_offset = random.uniform(-randomize, randomize)
                         
-                        # Apply the random offset to your touch location (assume x, y are current coordinates)
-                        initial_position[0] = initial_position[0] + x_offset
-                        initial_position[1] = initial_position[1] + y_offset
+                        # Calculate the potential new position
+                        new_x = initial_position[0] + x_offset
+                        new_y = initial_position[1] + y_offset
+                        
+                        # Clamp the new position to the original bounding box
+                        new_x = min(max(new_x, x_min), x_max)
+                        new_y = min(max(new_y, y_min), y_max)
+                        
+                        # Apply the clamped position
+                        initial_position[0] = new_x
+                        initial_position[1] = new_y
                         
                         self.toolhead.move(initial_position, 20)
                                              
                         # Respond with the randomized movement info
-                        gcmd.respond_info(f"Moving touch location slightly by (x: {x_offset:.2f}, y: {y_offset:.2f})")
+                        gcmd.respond_info(f"Moving touch location to (x: {new_x:.2f}, y: {new_y:.2f})")
                         new_retry = False
                         
                 self.toolhead.wait_moves()

--- a/scanner.py
+++ b/scanner.py
@@ -443,8 +443,6 @@ class Scanner:
             has_shown_retry_info = False  # Initialize the flag
             
             original_position = initial_position[:]
-            x_min, x_max = original_position[0] - randomize, original_position[0] + randomize
-            y_min, y_max = original_position[1] - randomize, original_position[1] + randomize
             
             while len(samples) < num_samples:
                 if retries > 0:
@@ -453,26 +451,18 @@ class Scanner:
                         has_shown_retry_info = True  # Set flag to True after showing the message
                 
                 if randomize > 0 and new_retry:
-                        # Generate random offsets within ±5 units for both x and y
+                        # Generate random offsets
                         x_offset = random.uniform(-randomize, randomize)
                         y_offset = random.uniform(-randomize, randomize)
                         
-                        # Calculate the potential new position
-                        new_x = initial_position[0] + x_offset
-                        new_y = initial_position[1] + y_offset
-                        
-                        # Clamp the new position to the original bounding box
-                        new_x = min(max(new_x, x_min), x_max)
-                        new_y = min(max(new_y, y_min), y_max)
-                        
-                        # Apply the clamped position
-                        initial_position[0] = new_x
-                        initial_position[1] = new_y
+                        # Adjust positiion
+                        initial_position[0] = original_position[0] + x_offset
+                        initial_position[1] = original_position[1] + y_offset
                         
                         self.toolhead.move(initial_position, 20)
                                              
                         # Respond with the randomized movement info
-                        gcmd.respond_info(f"Moving touch location to (x: {new_x:.2f}, y: {new_y:.2f})")
+                        gcmd.respond_info(f"Moving touch location to (x: {initial_position[0]:.2f}, y: {initial_position[1]:.2f})")
                         new_retry = False
                         
                 self.toolhead.wait_moves()


### PR DESCRIPTION
**Description**

When adding MOVE=(x) to `CARTOGRAPHER_TOUCH` upon a retry attempt, the toolhead will randomly pick a new location to touch based on a random number between -(x) and +(x) for both the x and y axis

Example: `CARTOGRAPHER_TOUCH MOVE=6` will randomly choose locations between the centre of the bed +-6 on X and Y resulting in toolhead potentially moving by +X2.75 -Y5.35 before touching again.

Issue #35 

![image](https://github.com/user-attachments/assets/0f32e391-77f6-4035-8a53-b9421188455e)


Signed-off-by: Chris Krause <[krause3284@gmail.com](mailto:krause3284@gmail.com)