### PR TITLE
fix: when calibrating dont apply any z offset

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -384,8 +384,6 @@ class Scanner:
             max_accel = self.toolhead.get_status(curtime)["max_accel"]
             self.log_debug_info(verbose, gcmd, f"Current Accel: {int(max_accel)}")
             
-            if calibrate == 1:
-                manual_z_offset = 0
             
             touch_settings = TouchSettings(initial_position, homing_position, accel, speed, retract_dist, retract_speed, num_samples, tolerance, max_retries, z_max, max_accel, test_threshold, manual_z_offset)
             result = self.start_touch(gcmd, touch_settings, verbose)
@@ -400,7 +398,7 @@ class Scanner:
                 self.log_debug_info(verbose, gcmd, f"Final position: {final_position}")
                 gcmd.respond_info(f"Standard Deviation: {standard_deviation:.4f}")
                 if calibrate == 1:
-                    self._calibrate(gcmd, final_position, final_position[2], True, True)
+                    self._calibrate(gcmd, final_position, 0, True, True)
                 
             else:
                 self.trigger_method = 0

--- a/scanner.py
+++ b/scanner.py
@@ -384,6 +384,9 @@ class Scanner:
             max_accel = self.toolhead.get_status(curtime)["max_accel"]
             self.log_debug_info(verbose, gcmd, f"Current Accel: {int(max_accel)}")
             
+            if calibrate == 1:
+                manual_z_offset = 0
+            
             touch_settings = TouchSettings(initial_position, homing_position, accel, speed, retract_dist, retract_speed, num_samples, tolerance, max_retries, z_max, max_accel, test_threshold, manual_z_offset)
             result = self.start_touch(gcmd, touch_settings, verbose)
             
@@ -492,7 +495,7 @@ class Scanner:
             initial_position[2] = float(adjusted_difference - position_difference)
             formatted_position = [f"{coord:.2f}" for coord in initial_position]
             self.log_debug_info(verbose, gcmd, f"Updated Initial Position: {formatted_position}")
-            if manual_z_offset >= 0 :
+            if manual_z_offset > 0 :
                 gcmd.respond_info(f"Offsetting by {manual_z_offset:.3f}")
                 initial_position[2] = initial_position[2] - manual_z_offset
             self.toolhead.set_position(initial_position)

--- a/scanner.py
+++ b/scanner.py
@@ -396,7 +396,6 @@ class Scanner:
             retries = result["retries"]
             success = result["success"]
             if success:
-                final_position[2] = final_position[2] - manual_z_offset
                 self.log_debug_info(verbose, gcmd, f"Touch procedure successful with {int(retries)} retries.")
                 self.log_debug_info(verbose, gcmd, f"Final position: {final_position}")
                 gcmd.respond_info(f"Standard Deviation: {standard_deviation:.4f}")


### PR DESCRIPTION
**Description**

When performing a `CARTOGRAPHER_TOUCH CALIBRATE=1` z offset will no longer be applied prior to calibration. This should fix any weird z_offset stacking issues.

Fixes Issue #51 


Signed-off-by: Chris Krause [krause3284@gmail.com](mailto:krause3284@gmail.com)