### PR TITLE
feature: save speed from threshold scan

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -51,6 +51,12 @@ TOUCH_SCALE = 0.0625 * adxl345.FREEFALL_ACCEL  # 62.5mg/LSB * Earth gravity in m
 
 ADXL345_REST_TIME = .1
 
+THRESHOLD_MIN_LIMIT = 750
+THRESHOLD_SCALING_FACTOR = 0.25
+THRESHOLD_ROUNDING_BASE = 250
+THRESHOLD_INCREMENT_MULTIPLIER = 5
+THRESHOLD_STEP_MULTIPLIER = 10
+
 class ThresholdResults:
     def __init__(self, max_value, min_value, range_value, avg_value, median, sigma, in_range, early, late, nb_samples):
      self.max_value = max_value
@@ -639,12 +645,6 @@ class Scanner:
             if hasattr(kinematics, "note_z_not_homed"):
                 kinematics.note_z_not_homed()
             raise
-
-    THRESHOLD_MIN_LIMIT = 750
-    THRESHOLD_SCALING_FACTOR = 0.25
-    THRESHOLD_ROUNDING_BASE = 250
-    THRESHOLD_INCREMENT_MULTIPLIER = 5
-    THRESHOLD_STEP_MULTIPLIER = 10
     
     cmd_SCANNER_THRESHOLD_SCAN_help = "Scan THRESHOLD in TOUCH mode"
 
@@ -680,6 +680,7 @@ class Scanner:
         threshold_max = gcmd.get_int("MAX", None)
         if threshold_max is None:
             threshold_max = threshold_min + (THRESHOLD_STEP_MULTIPLIER * step)
+        else:
             has_increased_threshold_max = (
                                 True  # max limit is set, dont increase
                             )
@@ -783,9 +784,9 @@ class Scanner:
                             has_increased_threshold_max = (
                                 True  # Set the flag to True after increasing
                             )
-                            gcmd.respond_info(
-                                f"Good Threshold Found: {current_threshold}. Adjusting threshold_max to {threshold_max}"
-                            )
+                        gcmd.respond_info(
+                            f"Good Threshold Found: {current_threshold}."
+                        )
 
                         # Run repeatability check with this threshold
                         consistent_results = True

--- a/scanner.py
+++ b/scanner.py
@@ -666,9 +666,16 @@ class Scanner:
         else:
             threshold_min = user_defined_min
 
+        has_increased_threshold_max = (
+            False  # Flag to track if threshold_max has been increased
+        )
+        
         threshold_max = gcmd.get_int("MAX", None)
         if threshold_max is None:
             threshold_max = threshold_min + (10 * step)
+            has_increased_threshold_max = (
+                                True  # max limit is set, dont increase
+                            )
 
         override = gcmd.get_int("OVERRIDE", 0)
 
@@ -692,9 +699,6 @@ class Scanner:
 
         # Prepare to track results
         results = []
-        has_increased_threshold_max = (
-            False  # Flag to track if threshold_max has been increased
-        )
 
         # Proceed with threshold scanning
         self.check_temp(gcmd)

--- a/scanner.py
+++ b/scanner.py
@@ -345,7 +345,7 @@ class Scanner:
             "target": gcmd.get_float(
                 "TARGET", 0.015, above=0.0
             ),  # Default target to 0.015 if not defined
-            "max_retries": gcmd.get_float(
+            "max_retries": gcmd.get_int(
                 "RETRIES", self.scanner_touch_config["max_retries"], minval=0
             ),
             "touch_location_x": gcmd.get_float(

--- a/scanner.py
+++ b/scanner.py
@@ -825,7 +825,7 @@ class Scanner:
                         # If all repeat attempts succeeded, save the threshold
                         if consistent_results and override == 0:
                             best_threshold = current_threshold
-                            self._save_threshold(best_threshold)
+                            self._save_threshold(best_threshold, vars["speed"])
                             break
                 # Move to the next candidate if current threshold didn't succeed
                 current_threshold += step
@@ -873,7 +873,7 @@ class Scanner:
 
             # Save and respond with the best threshold found
             self.detect_threshold_z = best_threshold
-            self._save_threshold(best_threshold)
+            self._save_threshold(best_threshold, vars["speed"])
 
             # Handle None for standard deviation by using a default message
             std_dev_display = (
@@ -2091,9 +2091,10 @@ class Scanner:
         pos = self.run_probe(gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
 
-    def _save_threshold(self, threshold):
+    def _save_threshold(self, threshold, speed):
         configfile = self.printer.lookup_object('configfile')
         configfile.set("scanner", "scanner_touch_threshold", "%d" % int(threshold))
+        configfile.set("scanner", "scanner_touch_speed", "%d" % int(speed))
 
     cmd_SCANNER_THRESHOLD_TEST_help = "Home using touch and check with coil to see how consistent it is"
     def cmd_SCANNER_THRESHOLD_TEST(self, gcmd):

--- a/scanner.py
+++ b/scanner.py
@@ -572,7 +572,7 @@ class Scanner:
                     f"Touch {len(samples)} result: {probe_position[2]:.4f}",
                 )
 
-                average = np.mean(samples)
+                average = np.median(samples)
                 deviation = max(abs(sample - average) for sample in samples)
 
                 deviation = round(deviation, 4)

--- a/scanner.py
+++ b/scanner.py
@@ -56,6 +56,8 @@ THRESHOLD_SCALING_FACTOR = 0.25
 THRESHOLD_ROUNDING_BASE = 250
 THRESHOLD_INCREMENT_MULTIPLIER = 5
 THRESHOLD_STEP_MULTIPLIER = 10
+# Require a qualified threshold to pass at 0.66 of the QUALIFY_SAMPLES
+THRESHOLD_ACCEPTANCE_FACTOR = 0.66
 
 class ThresholdResults:
     def __init__(self, max_value, min_value, range_value, avg_value, median, sigma, in_range, early, late, nb_samples):
@@ -695,7 +697,7 @@ class Scanner:
         )  # Define repeat attempts for consistency check
 
         # Define what qualifies as a "good" result
-        max_acceptable_retries = 3
+        max_acceptable_retries = round(confirmation_retries * THRESHOLD_ACCEPTANCE_FACTOR)
         max_acceptable_std_dev = vars["target"]
 
         verbose = vars["verbose"]

--- a/scanner.py
+++ b/scanner.py
@@ -989,9 +989,6 @@ class Scanner:
             std_dev = np.std(samples) if samples else None
             if len(samples) == num_samples:
                 success = True
-                gcmd.respond_info(
-                    f"Completed {len(samples)} touches with a standard deviation of {std_dev:.4f}"
-                )
                 position_difference = (
                     initial_position[2] - self.toolhead.get_position()[2]
                 )

--- a/scanner.py
+++ b/scanner.py
@@ -678,7 +678,7 @@ class Scanner:
         else:
             threshold_min = user_defined_min
 
-        threshold_max = gcmd.get_int("MAX", None, maxval=5000)
+        threshold_max = gcmd.get_int("MAX", None)
         if threshold_max is None:
             threshold_max = threshold_min + (10 * step)
 

--- a/scanner.py
+++ b/scanner.py
@@ -787,12 +787,12 @@ class Scanner:
                                 > max_acceptable_std_dev
                             ):
                                 gcmd.respond_info(
-                                    f"Repeat attempt {attempt + 1} failed for threshold {current_threshold}"
+                                    f"Qualify attempt {attempt + 1} failed for threshold {current_threshold}"
                                 )
                                 consistent_results = False
                                 break
                             gcmd.respond_info(
-                                f"Repeat attempt {attempt + 1} successful with std dev: {repeat_result['standard_deviation']:.5f}"
+                                f"Qualify attempt {attempt + 1} successful with std dev: {repeat_result['standard_deviation']:.5f}"
                             )
 
                         # Save only successful repeat attempts in results
@@ -812,9 +812,6 @@ class Scanner:
                         if consistent_results and override == 0:
                             best_threshold = current_threshold
                             self._save_threshold(best_threshold)
-                            gcmd.respond_info(
-                                f"Confirmed Optimal Threshold Found: {best_threshold}"
-                            )
                             break
                 # Move to the next candidate if current threshold didn't succeed
                 current_threshold += step
@@ -874,11 +871,11 @@ class Scanner:
             # Inform the user about the result
             if optimal_found:
                 gcmd.respond_info(
-                    f"Optimal Threshold Determined: {best_threshold} with {best_result['retries']} retries and standard deviation of {std_dev_display}"
+                    f"Optimal Threshold Determined: {best_threshold} with standard deviation of {std_dev_display}"
                 )
             else:
                 gcmd.respond_info(
-                    f"No fully optimal threshold found. Best attempt: {best_threshold} with {best_result['retries']} retries and standard deviation of {std_dev_display}"
+                    f"No fully optimal threshold found. Best attempt: {best_threshold} with standard deviation of {std_dev_display}"
                 )
             gcmd.respond_info(f"You can now SAVE_CONFIG to save your threshold.")
 

--- a/scanner.py
+++ b/scanner.py
@@ -640,6 +640,12 @@ class Scanner:
                 kinematics.note_z_not_homed()
             raise
 
+    THRESHOLD_MIN_LIMIT = 750
+    THRESHOLD_SCALING_FACTOR = 0.25
+    THRESHOLD_ROUNDING_BASE = 250
+    THRESHOLD_INCREMENT_MULTIPLIER = 5
+    THRESHOLD_STEP_MULTIPLIER = 10
+    
     cmd_SCANNER_THRESHOLD_SCAN_help = "Scan THRESHOLD in TOUCH mode"
 
     def cmd_SCANNER_THRESHOLD_SCAN(self, gcmd):
@@ -661,7 +667,8 @@ class Scanner:
 
         if user_defined_min is None:
             threshold_min = max(
-                750, round((self.detect_threshold_z * 0.25) / 250) * 250
+                THRESHOLD_MIN_LIMIT, 
+                round((self.detect_threshold_z * THRESHOLD_SCALING_FACTOR) / THRESHOLD_ROUNDING_BASE) * THRESHOLD_ROUNDING_BASE
             )
         else:
             threshold_min = user_defined_min
@@ -672,7 +679,7 @@ class Scanner:
         
         threshold_max = gcmd.get_int("MAX", None)
         if threshold_max is None:
-            threshold_max = threshold_min + (10 * step)
+            threshold_max = threshold_min + (THRESHOLD_STEP_MULTIPLIER * step)
             has_increased_threshold_max = (
                                 True  # max limit is set, dont increase
                             )
@@ -772,7 +779,7 @@ class Scanner:
                     ):
                         # Increase threshold_max by 3 steps above the current threshold, only if it hasn't been increased before
                         if not has_increased_threshold_max:
-                            threshold_max = current_threshold + 5 * step
+                            threshold_max = current_threshold + THRESHOLD_INCREMENT_MULTIPLIER * step
                             has_increased_threshold_max = (
                                 True  # Set the flag to True after increasing
                             )

--- a/scanner.py
+++ b/scanner.py
@@ -305,7 +305,7 @@ class Scanner:
             self.calibration_method = "scan"
             self._start_calibration(gcmd)
                                 
-   def _get_common_variables(self, gcmd):
+    def _get_common_variables(self, gcmd):
         return {
             "speed": gcmd.get_float(
                 "SPEED",


### PR DESCRIPTION
## Description

When performing `CARTOGRAPHER_THRESHOLD_SCAN` it will save SPEED=x to `scanner_touch_speed` in printer.cfg

## Checklist

The following relevant macros have been tested:

- [x] `CARTOGRAPHER_CALIBRATE`
- [x] `PROBE`
- [x] `PROBE_ACCURACY`
- [x] `CARTOGRAPHER_THRESHOLD_SCAN`
- [x] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [x] `CARTOGRAPHER_TOUCH`
- [x] `CARTOGRAPHER_TOUCH METHOD=manual`
- [x] `BED_MESH_CALIBRATE`
