### PR TITLE
Feature: model mode switching & command update

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -413,9 +413,10 @@ class Scanner:
             self.init_adxl()
         else:
             self.trigger_method = 0
-            raise gcmd.error(
-                "Must use touch or adxl mode. Check your config before trying again."
-            )
+            self.calibration_method = "scan"
+            if calibrate == 1 or gcmd.get("METHOD", "None").lower() == "manual":
+                self._start_calibration(gcmd)
+            return
         
         self.check_temp(gcmd)
         self.log_debug_info(

--- a/scanner.py
+++ b/scanner.py
@@ -313,7 +313,14 @@ class Scanner:
     cmd_SCANNER_CALIBRATE_help = "Calibrate scanner response curve"
     def cmd_SCANNER_CALIBRATE(self,gcmd):
         if self.calibration_method != "scan":
-            raise gcmd.error("You are not in scan mode. Please set 'calibration_method: scan' in your printer.cfg and retry.")
+            cmd = self.sensor_name + "_TOUCH"
+            params = {}
+            if gcmd.get("METHOD","None").lower() == "manual":
+                params["METHOD"] = "manual"
+            else:
+                params["CALIBRATE"] = "1"
+            cmd = self.gcode.create_gcode_command(cmd, cmd, params)
+            self.cmd_SCANNER_TOUCH(cmd)
         else:
             self.calibration_method = "scan"
             self._start_calibration(gcmd)

--- a/scanner.py
+++ b/scanner.py
@@ -1652,7 +1652,7 @@ class Scanner:
         temp_median = median(temp)
         self.model = ScannerModel(model_name,
                                  self, poly, temp_median,
-                                 min(z_offset), max(z_offset))
+                                 min(z_offset), max(z_offset), self.calibration_method)
         self.models[self.model.name] = self.model
         self.model.save(self)
         self._apply_threshold()
@@ -1748,7 +1748,7 @@ class Scanner:
         temp_median = median(temp)
         self.model = ScannerModel(model_name,
                                  self, poly, temp_median,
-                                 min(z_offset), max(z_offset))
+                                 min(z_offset), max(z_offset), self.calibration_method)
         self.models[self.model.name] = self.model
         self.model.save(self)
         self._apply_threshold()
@@ -2480,10 +2480,11 @@ class ScannerModel:
         domain = config.getfloatlist("model_domain", count=2)
         [min_z, max_z] = config.getfloatlist("model_range", count=2)
         offset = config.getfloat("model_offset", 0.0)
+        mode = config.get("model_mode", "None")
         poly = Polynomial(coef, domain)
-        return ScannerModel(name, scanner, poly, temp, min_z, max_z, offset)
+        return ScannerModel(name, scanner, poly, temp, min_z, max_z, mode, offset)
 
-    def __init__(self, name, scanner, poly, temp, min_z, max_z, offset=0):
+    def __init__(self, name, scanner, poly, temp, min_z, max_z, mode, offset=0):
         self.name = name
         self.scanner = scanner
         self.poly = poly
@@ -2491,6 +2492,7 @@ class ScannerModel:
         self.max_z = max_z
         self.temp = temp
         self.offset = offset
+        self.mode = mode
 
     def save(self, scanner, show_message=True):
         configfile = scanner.printer.lookup_object("configfile")
@@ -2504,6 +2506,8 @@ class ScannerModel:
         configfile.set(section, "model_temp",
                        "%f" % (self.temp))
         configfile.set(section, "model_offset", "%.5f" % (self.offset,))
+        configfile.set(section, "model_mode",
+                       "%s" % (self.scanner.calibration_method))
         if show_message:
             scanner.gcode.respond_info("Scanner calibration for model '%s' has "
                     "been updated\nfor the current session. The SAVE_CONFIG "

--- a/scanner.py
+++ b/scanner.py
@@ -150,7 +150,7 @@ class Scanner:
         self.touch_dur = config.getfloat('touch_dur', 0.01, above=DUR_SCALE, maxval=0.1)
         self.adxl345 = None
 
-        self.calibration_method = config.get("calibration_method","scan")
+        self.calibration_method = config.get("mode", config.get("calibration_method", "scan"))
         self.trigger_method = 0
 
         self.trigger_distance = config.getfloat("trigger_distance", 2.0)


### PR DESCRIPTION
## Description

Adds mode to models as well as renames and remaps associates commands with fallbacks.

### What changed?
`[scanner]`
- renamed `calibration_method` to `mode` (calibration_method is still available)

`[scanner model NAME]`
- added `model_mode: scan/touch` (based on whether youre using touch or not)

### Command Changes

`PROBE_SWITCH` will now change what mode you're in, either scan or touch and will ask you to `SAVE_CONFIG` in order to update `mode` under [scanner]

**Previous:** `CARTOGRAPHER_TOUCH CALIBRATE=1` (still works)
**Now:** `CARTOGRAPHER_CALIBRATE`

---------------------------

**Previous:** `CARTOGRAPHER_TOUCH METHOD=manual` (still works)
**Now:** `CARTOGRAPHER_CALIBRATE METHOD=manual`

## Checklist

The following relevant macros have been tested:

- [x] `CARTOGRAPHER_CALIBRATE`
- [x] `PROBE`
- [x] `PROBE_ACCURACY`
- [x] `CARTOGRAPHER_THRESHOLD_SCAN`
- [x] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [x] `CARTOGRAPHER_TOUCH`
- [x] `CARTOGRAPHER_TOUCH METHOD=manual`
- [x] `BED_MESH_CALIBRATE`
