### PR TITLE
fix: missing imports

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -25,7 +25,11 @@ import struct
 import numpy as np
 import copy
 import os
+import csv
 import random
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+from matplotlib.ticker import FuncFormatter
 from numpy.polynomial import Polynomial
 from . import manual_probe
 from . import probe


### PR DESCRIPTION
## Description

Re-added missing imports for debugging graph generation

import csv
import matplotlib.pyplot as plt
import matplotlib.ticker as ticker
from matplotlib.ticker import FuncFormatter

## Checklist

The following relevant macros have been tested:

- [x] `CARTOGRAPHER_CALIBRATE`
- [x] `PROBE`
- [x] `PROBE_ACCURACY`
- [x] `CARTOGRAPHER_THRESHOLD_SCAN`
- [x] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [x] `CARTOGRAPHER_TOUCH`
- [x] `CARTOGRAPHER_TOUCH METHOD=manual`
- [x] `BED_MESH_CALIBRATE`
