### PR TITLE
Fix: stops users setting offet below 0

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -2404,12 +2404,15 @@ class Scanner:
         return ThresholdResults(max_value, min_value, range_value, avg_value, median_, sigma, in_range, early, late, len(zs))
 
     cmd_Z_OFFSET_APPLY_PROBE_help = "Adjust the probe's z_offset"
-  def cmd_Z_OFFSET_APPLY_PROBE(self, gcmd):
+    def cmd_Z_OFFSET_APPLY_PROBE(self, gcmd):
         gcode_move = self.printer.lookup_object("gcode_move")
         offset = gcode_move.get_status()["homing_origin"].z
         if offset == 0:
             self.gcode.respond_info("Nothing to do: Z Offset is 0")
             return
+            
+        if not self.model:
+            raise self.gcode.error("You must calibrate your model first.")
          
         if self.calibration_method == "touch":
             newoffset = self.scanner_touch_config['z_offset']
@@ -2422,10 +2425,6 @@ class Scanner:
                     "However it cannot be less than 0. So its been set to 0.\n"
                     "Please check your printers calibration and try again.")
                 return
-
-        if not self.model:
-            raise self.gcode.error("You must calibrate your model first, "
-                                   "use SCANNER_CALIBRATE.")
                                    
         
         else:

--- a/scanner.py
+++ b/scanner.py
@@ -2447,8 +2447,7 @@ class Scanner:
             gcmd.respond_info(f"Scanner model offset has been updated to {self.model.offset:.3f}.\n"
                     "You must run the SAVE_CONFIG command now to update the\n"
                     "printer config file and restart the printer.")
-            self.model.offset = old_offset
-
+                    
     cmd_SAVE_TOUCH_OFFSET_help = "Save offset to z_offset for TOUCH method"
     def cmd_SAVE_TOUCH_OFFSET(self, gcmd):
         gcode_move = self.printer.lookup_object("gcode_move")

--- a/scanner.py
+++ b/scanner.py
@@ -2434,13 +2434,12 @@ class Scanner:
                 # offset would compound with the gcode offset. To ensure this doesn't
                 # happen, we revert to the old model offset afterwards.
                 # Really, the user should just be calling `SAVE_CONFIG` now.
-                if self.calibration_method == "touch":
-                    self.scanner_touch_config['z_offset'] = newoffset
-                    configfile = self.printer.lookup_object('configfile')
-                    configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % self.scanner_touch_config['z_offset'])
-                    gcmd.respond_info(f"Touch offset has been updated by {offset:.3f} to {self.scanner_touch_config['z_offset']:.3f}.\n"
-                        "You must run the SAVE_CONFIG command now to update the\n"
-                        "printer config file and restart the printer.")
+                self.scanner_touch_config['z_offset'] = newoffset
+                configfile = self.printer.lookup_object('configfile')
+                configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % self.scanner_touch_config['z_offset'])
+                gcmd.respond_info(f"Touch offset has been updated by {offset:.3f} to {self.scanner_touch_config['z_offset']:.3f}.\n"
+                    "You must run the SAVE_CONFIG command now to update the\n"
+                    "printer config file and restart the printer.")
         else:
             old_offset = self.model.offset
             self.model.offset += offset

--- a/scanner.py
+++ b/scanner.py
@@ -2427,28 +2427,28 @@ class Scanner:
                 return
                                    
         
-        else:
-            # We use the model code to save the new offset, but we can't actually
-            # apply that offset yet because the gcode_offset is still in effect.
-            # If the user continues to do stuff after this, the newly set model
-            # offset would compound with the gcode offset. To ensure this doesn't
-            # happen, we revert to the old model offset afterwards.
-            # Really, the user should just be calling `SAVE_CONFIG` now.
-            if self.calibration_method == "touch":
-                self.scanner_touch_config['z_offset'] = newoffset
-                configfile = self.printer.lookup_object('configfile')
-                configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % self.scanner_touch_config['z_offset'])
-                gcmd.respond_info(f"Touch offset has been updated by {offset:.3f} to {self.scanner_touch_config['z_offset']:.3f}.\n"
-                    "You must run the SAVE_CONFIG command now to update the\n"
-                    "printer config file and restart the printer.")
             else:
-                old_offset = self.model.offset
-                self.model.offset += offset
-                self.model.save(self, False)
-                gcmd.respond_info(f"Scanner model offset has been updated to {self.model.offset:.3f}.\n"
+                # We use the model code to save the new offset, but we can't actually
+                # apply that offset yet because the gcode_offset is still in effect.
+                # If the user continues to do stuff after this, the newly set model
+                # offset would compound with the gcode offset. To ensure this doesn't
+                # happen, we revert to the old model offset afterwards.
+                # Really, the user should just be calling `SAVE_CONFIG` now.
+                if self.calibration_method == "touch":
+                    self.scanner_touch_config['z_offset'] = newoffset
+                    configfile = self.printer.lookup_object('configfile')
+                    configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % self.scanner_touch_config['z_offset'])
+                    gcmd.respond_info(f"Touch offset has been updated by {offset:.3f} to {self.scanner_touch_config['z_offset']:.3f}.\n"
                         "You must run the SAVE_CONFIG command now to update the\n"
                         "printer config file and restart the printer.")
-                self.model.offset = old_offset
+        else:
+            old_offset = self.model.offset
+            self.model.offset += offset
+            self.model.save(self, False)
+            gcmd.respond_info(f"Scanner model offset has been updated to {self.model.offset:.3f}.\n"
+                    "You must run the SAVE_CONFIG command now to update the\n"
+                    "printer config file and restart the printer.")
+            self.model.offset = old_offset
 
     cmd_SAVE_TOUCH_OFFSET_help = "Save offset to z_offset for TOUCH method"
     def cmd_SAVE_TOUCH_OFFSET(self, gcmd):

--- a/scanner.py
+++ b/scanner.py
@@ -2418,7 +2418,7 @@ class Scanner:
             newoffset = self.scanner_touch_config['z_offset']
             newoffset += offset
             if newoffset < 0:
-                self.scanner_touch_config['z_offset'] = newoffset
+                self.scanner_touch_config['z_offset'] = 0
                 configfile = self.printer.lookup_object('configfile')
                 configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % 0)
                 gcmd.respond_info(f"Touch offset attempted to update to {newoffset:.3f}.\n"

--- a/scanner.py
+++ b/scanner.py
@@ -2404,37 +2404,52 @@ class Scanner:
         return ThresholdResults(max_value, min_value, range_value, avg_value, median_, sigma, in_range, early, late, len(zs))
 
     cmd_Z_OFFSET_APPLY_PROBE_help = "Adjust the probe's z_offset"
-    def cmd_Z_OFFSET_APPLY_PROBE(self, gcmd):
+  def cmd_Z_OFFSET_APPLY_PROBE(self, gcmd):
         gcode_move = self.printer.lookup_object("gcode_move")
         offset = gcode_move.get_status()["homing_origin"].z
         if offset == 0:
             self.gcode.respond_info("Nothing to do: Z Offset is 0")
             return
+         
+        if self.calibration_method == "touch":
+            newoffset = self.scanner_touch_config['z_offset']
+            newoffset += offset
+            if newoffset < 0:
+                self.scanner_touch_config['z_offset'] = newoffset
+                configfile = self.printer.lookup_object('configfile')
+                configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % 0)
+                gcmd.respond_info(f"Touch offset attempted to update to {newoffset:.3f}.\n"
+                    "However it cannot be less than 0. So its been set to 0.\n"
+                    "Please check your printers calibration and try again.")
+                return
 
         if not self.model:
             raise self.gcode.error("You must calibrate your model first, "
                                    "use SCANNER_CALIBRATE.")
-
-        # We use the model code to save the new offset, but we can't actually
-        # apply that offset yet because the gcode_offset is still in effect.
-        # If the user continues to do stuff after this, the newly set model
-        # offset would compound with the gcode offset. To ensure this doesn't
-        # happen, we revert to the old model offset afterwards.
-        # Really, the user should just be calling `SAVE_CONFIG` now.
-        if self.calibration_method == "touch":
-            self.scanner_touch_config['z_offset'] += offset
-            configfile = self.printer.lookup_object('configfile')
-            configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % self.scanner_touch_config['z_offset'])
-            gcmd.respond_info(f"Touch offset has been updated by {offset:.3f} to {self.scanner_touch_config['z_offset']:.3f}.\n"
-                    "You must run the SAVE_CONFIG command now to update the\n"
-                    "printer config file and restart the printer.")
-
+                                   
+        
         else:
-            self.model.offset += offset
-            self.model.save(self, False)
-            gcmd.respond_info(f"Scanner model offset has been updated to {self.model.offset:.3f}.\n"
+            # We use the model code to save the new offset, but we can't actually
+            # apply that offset yet because the gcode_offset is still in effect.
+            # If the user continues to do stuff after this, the newly set model
+            # offset would compound with the gcode offset. To ensure this doesn't
+            # happen, we revert to the old model offset afterwards.
+            # Really, the user should just be calling `SAVE_CONFIG` now.
+            if self.calibration_method == "touch":
+                self.scanner_touch_config['z_offset'] = newoffset
+                configfile = self.printer.lookup_object('configfile')
+                configfile.set("scanner", "scanner_touch_z_offset", "%.3f" % self.scanner_touch_config['z_offset'])
+                gcmd.respond_info(f"Touch offset has been updated by {offset:.3f} to {self.scanner_touch_config['z_offset']:.3f}.\n"
                     "You must run the SAVE_CONFIG command now to update the\n"
                     "printer config file and restart the printer.")
+            else:
+                old_offset = self.model.offset
+                self.model.offset += offset
+                self.model.save(self, False)
+                gcmd.respond_info(f"Scanner model offset has been updated to {self.model.offset:.3f}.\n"
+                        "You must run the SAVE_CONFIG command now to update the\n"
+                        "printer config file and restart the printer.")
+                self.model.offset = old_offset
 
     cmd_SAVE_TOUCH_OFFSET_help = "Save offset to z_offset for TOUCH method"
     def cmd_SAVE_TOUCH_OFFSET(self, gcmd):


### PR DESCRIPTION
## Description

Quick change i pulled from KrauTech V2 that stops users setting offset below 0 and tells them to check calibration etc.

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
