### PR TITLE
Make MOVE argument configurable

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -201,6 +201,7 @@ class Scanner:
             "z_offset": config.getfloat("scanner_touch_z_offset", 0.05),
             "threshold": config.getint("scanner_touch_threshold", 2500),
             "max_temp": config.getfloat("scanner_touch_max_temp", 150),
+            "move": config.getfloat("scanner_touch_move", 0),
         }
         self.gcode = self.printer.lookup_object("gcode")
         self.probe_calibrate_z = 0.0
@@ -424,7 +425,9 @@ class Scanner:
             "touch_location_y": gcmd.get_float(
                 "TOUCH_LOCATION_Y", float(self.touch_location[1])
             ),
-            "randomize": gcmd.get_float("MOVE", 0, maxval=10),
+            "randomize": gcmd.get_float(
+                "MOVE", self.scanner_touch_config["move"], maxval=10
+            ),
             "verbose": gcmd.get_int("DEBUG", 0),
         }
 

--- a/scanner.py
+++ b/scanner.py
@@ -201,7 +201,7 @@ class Scanner:
             "z_offset": config.getfloat("scanner_touch_z_offset", 0.05),
             "threshold": config.getint("scanner_touch_threshold", 2500),
             "max_temp": config.getfloat("scanner_touch_max_temp", 150),
-            "fuzzy_touch": config.getfloat("scanner_touch_fuzzy_touch", 0),
+            "fuzzy_touch": config.getfloat("scanner_touch_fuzzy_touch", 0, maxval=10),
         }
         self.gcode = self.printer.lookup_object("gcode")
         self.probe_calibrate_z = 0.0

--- a/scanner.py
+++ b/scanner.py
@@ -201,7 +201,7 @@ class Scanner:
             "z_offset": config.getfloat("scanner_touch_z_offset", 0.05),
             "threshold": config.getint("scanner_touch_threshold", 2500),
             "max_temp": config.getfloat("scanner_touch_max_temp", 150),
-            "move": config.getfloat("scanner_touch_move", 0),
+            "fuzzy_touch": config.getfloat("scanner_touch_fuzzy_touch", 0),
         }
         self.gcode = self.printer.lookup_object("gcode")
         self.probe_calibrate_z = 0.0
@@ -426,7 +426,7 @@ class Scanner:
                 "TOUCH_LOCATION_Y", float(self.touch_location[1])
             ),
             "randomize": gcmd.get_float(
-                "MOVE", self.scanner_touch_config["move"], maxval=10
+                "FUZZZY_TOUCH", self.scanner_touch_config["fuzzy_touch"], maxval=10
             ),
             "verbose": gcmd.get_int("DEBUG", 0),
         }


### PR DESCRIPTION
## Description:

This adds a config option to set a default value for `MOVE`.
![image](https://github.com/user-attachments/assets/bc3283df-5849-485c-a55a-fff670a28b90)
![image](https://github.com/user-attachments/assets/eada32e8-b16b-4d7a-8afc-36cc8e20d893)

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`