### PR TITLE
Add types for gcode and gcode command

### DIFF
--- a/typings/configfile.pyi
+++ b/typings/configfile.pyi
@@ -29,7 +29,7 @@ class ConfigWrapper:
     def get(
         self,
         option: str,
-        default: str,
+        default: str | type[sentinel] = sentinel,
         note_valid: bool = True,
     ) -> str:
         pass
@@ -41,20 +41,12 @@ class ConfigWrapper:
         note_valid: bool = True,
     ) -> str | None:
         pass
-    @overload
-    def get(
-        self,
-        option: str,
-        default: type[sentinel] = sentinel,
-        note_valid: bool = True,
-    ) -> str:
-        pass
 
     @overload
     def getint(
         self,
         option: str,
-        default: int,
+        default: int | type[sentinel] = sentinel,
         minval: int | None = None,
         maxval: int | None = None,
         note_valid: bool = True,
@@ -70,22 +62,12 @@ class ConfigWrapper:
         note_valid: bool = True,
     ) -> int | None:
         pass
-    @overload
-    def getint(
-        self,
-        option: str,
-        default: type[sentinel],
-        minval: int | None = None,
-        maxval: int | None = None,
-        note_valid: bool = True,
-    ) -> int:
-        pass
 
     @overload
     def getfloat(
         self,
         option: str,
-        default: float,
+        default: float | type[sentinel] = sentinel,
         minval: float | None = None,
         maxval: float | None = None,
         above: float | None = None,
@@ -105,24 +87,12 @@ class ConfigWrapper:
         note_valid: bool = True,
     ) -> float | None:
         pass
-    @overload
-    def getfloat(
-        self,
-        option: str,
-        default: type[sentinel] = sentinel,
-        minval: float | None = None,
-        maxval: float | None = None,
-        above: float | None = None,
-        below: float | None = None,
-        note_valid: bool = True,
-    ) -> float:
-        pass
 
     @overload
     def getboolean(
         self,
         option: str,
-        default: bool,
+        default: bool | type[sentinel] = sentinel,
         note_valid: bool = True,
     ) -> bool:
         pass
@@ -134,21 +104,13 @@ class ConfigWrapper:
         note_valid: bool = True,
     ) -> bool | None:
         pass
-    @overload
-    def getboolean(
-        self,
-        option: str,
-        default: type[sentinel] = sentinel,
-        note_valid: bool = True,
-    ) -> bool:
-        pass
 
     @overload
     def getchoice(
         self,
         option: str,
         choices: dict[str, str],
-        default: str,
+        default: str | type[sentinel] = sentinel,
         note_valid: bool = True,
     ) -> str:
         pass
@@ -161,12 +123,46 @@ class ConfigWrapper:
         note_valid: bool = True,
     ) -> str | None:
         pass
+
     @overload
-    def getchoice(
+    def getintlist(
         self,
         option: str,
-        choices: dict[str, str],
-        default: type[sentinel] = sentinel,
+        default: list[int] | type[sentinel] = sentinel,
+        sep: str = ",",
+        count: int | None = None,
         note_valid: bool = True,
-    ) -> str:
+    ) -> list[int]:
+        pass
+
+    @overload
+    def getintlist(
+        self,
+        option: str,
+        default: None,
+        sep: str = ",",
+        count: int | None = None,
+        note_valid: bool = True,
+    ) -> list[int] | None:
+        pass
+
+    @overload
+    def getfloatlist(
+        self,
+        option: str,
+        default: list[float] | type[sentinel] = sentinel,
+        sep: str = ",",
+        count: int | None = None,
+        note_valid: bool = True,
+    ) -> list[float]:
+        pass
+    @overload
+    def getfloatlist(
+        self,
+        option: str,
+        default: None,
+        sep: str = ",",
+        count: int | None = None,
+        note_valid: bool = True,
+    ) -> list[float] | None:
         pass

--- a/typings/gcode.pyi
+++ b/typings/gcode.pyi
@@ -1,5 +1,119 @@
-from typing import final
+from typing import Callable, NamedTuple, final, overload
 
 @final
 class CommandError(Exception):
     pass
+
+@final
+class GCodeCommand:
+    error = CommandError
+    class sentinel:
+        pass
+
+    def respond_raw(self, msg: str) -> None:
+        pass
+    def respond_info(self, msg: str, log: bool = True) -> None:
+        pass
+
+    @overload
+    def get(
+        self,
+        name: str,
+        default: str | type[sentinel] = sentinel,
+    ) -> str:
+        pass
+    @overload
+    def get(
+        self,
+        name: str,
+        default: None,
+    ) -> str | None:
+        pass
+
+    @overload
+    def get_int(
+        self,
+        name: str,
+        default: int | type[sentinel] = sentinel,
+        minval: int | None = None,
+        maxval: int | None = None,
+    ) -> int:
+        pass
+    @overload
+    def get_int(
+        self,
+        name: str,
+        default: None,
+        minval: int | None = None,
+        maxval: int | None = None,
+    ) -> int | None:
+        pass
+
+    @overload
+    def get_float(
+        self,
+        name: str,
+        default: float | type[sentinel] = sentinel,
+        minval: float | None = None,
+        maxval: float | None = None,
+        above: float | None = None,
+        below: float | None = None,
+    ) -> float:
+        pass
+    @overload
+    def get_float(
+        self,
+        name: str,
+        default: None,
+        minval: float | None = None,
+        maxval: float | None = None,
+        above: float | None = None,
+        below: float | None = None,
+    ) -> float | None:
+        pass
+
+class Coord(NamedTuple):
+    x: float
+    y: float
+    z: float
+    e: float
+
+@final
+class GCodeDispatch:
+    error = CommandError
+    Coord: type[Coord]
+
+    def respond_raw(self, msg: str) -> None:
+        pass
+    def respond_info(self, msg: str, log: bool = True) -> None:
+        pass
+
+    def run_script_from_command(self, script: str) -> None:
+        pass
+
+    @overload
+    def register_command(
+        self,
+        cmd: str,
+        func: Callable[[GCodeCommand], None],
+        when_not_ready: bool = False,
+        desc: str | None = None,
+    ) -> None:
+        pass
+    @overload
+    def register_command(
+        self,
+        cmd: str,
+        func: None,
+        when_not_ready: bool = False,
+        desc: str | None = None,
+    ) -> Callable[[GCodeCommand], None]:
+        pass
+
+    def create_gcode_command(
+        self,
+        command: str,
+        commandline: str,
+        params: dict[str, str],
+    ) -> GCodeCommand:
+        pass

--- a/typings/klippy.pyi
+++ b/typings/klippy.pyi
@@ -1,4 +1,3 @@
-import configparser
 from typing import Callable, TypeVar, final
 
 from configfile import ConfigWrapper, sentinel
@@ -14,8 +13,10 @@ class Printer:
     command_error = gcode.CommandError
     def add_object(self, name: str, obj: object) -> None:
         pass
+
     def lookup_object(self, name: str, default: T | type[sentinel] = sentinel) -> T:
         pass
+
     def load_object(
         self,
         config: ConfigWrapper,
@@ -23,6 +24,7 @@ class Printer:
         default: T | type[sentinel] = sentinel,
     ) -> T:
         pass
+
     def is_shutdown(self) -> bool:
         pass
     def invoke_shutdown(self, msg: str) -> None:

--- a/typings/reactor.pyi
+++ b/typings/reactor.pyi
@@ -19,3 +19,5 @@ class Reactor:
         self, callback: Callable[[float], None], waketime: float = NOW
     ) -> None:
         pass
+    def pause(self, waketime: float) -> float:
+        pass


### PR DESCRIPTION
## Description

This creates types for `gcode` and `gcmd` variables.
The stubs are based off the code in https://github.com/Klipper3d/klipper/blob/f2e69a3703f97725fb0db626ff592a223e22b3a2/klippy/gcode.py

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
