### PR TITLE
Check firmware version before homing

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -37,6 +37,9 @@ from klippy import Printer
 
 from . import bed_mesh, manual_probe, probe, thermistor
 
+DOCS_TOUCH_CALIBRATION = "https://docs.cartographer3d.com/cartographer-probe/installation-and-setup/installation/touch-based-calibration"
+DOCS_SCAN_CALIBRATION = "https://docs.cartographer3d.com/cartographer-probe/installation-and-setup/installation/scan-based-calibration"
+
 STREAM_BUFFER_LIMIT_DEFAULT = 100
 STREAM_TIMEOUT = 2.0
 
@@ -2379,9 +2382,13 @@ class ScannerModel:
     def validate(self) -> None:
         cur_fw = self.scanner.fw_version
         if cur_fw != self.fw_version:
+            url = DOCS_TOUCH_CALIBRATION
+            if self.mode == "scan":
+                url = DOCS_SCAN_CALIBRATION
             raise self.scanner.printer.command_error(
                 f"Scanner model '{self.name}' was created with firmware version '{self.fw_version}', "
-                f"current firmware version is '{cur_fw}'. Please recalibrate the model."
+                f"current firmware version is '{cur_fw}'. Please recalibrate the your threshold and model."
+                f" Click <a href='{url}'>HERE</a> for more information"
             )
 
     def freq_to_dist_raw(self, freq):

--- a/scanner.py
+++ b/scanner.py
@@ -2822,9 +2822,6 @@ class ScannerEndstopWrapper:
         printer.register_event_handler(
             "homing:homing_move_begin", self._handle_homing_move_begin
         )
-        printer.register_event_handler(
-            "homing:homing_move_end", self._handle_homing_move_end
-        )
         self.z_homed = False
         self.is_homing = False
 
@@ -2874,15 +2871,6 @@ class ScannerEndstopWrapper:
                         self.scanner.trigger_method,
                     ]
                 )
-            elif self.scanner.trigger_method == 2:
-                self.scanner.mcu_probe.probe_prepare(hmove)
-
-    def _handle_homing_move_end(self, hmove):
-        if (
-            self.scanner.mcu_probe in hmove.get_mcu_endstops()
-            and self.scanner.trigger_method == 2
-        ):
-            self.scanner.mcu_probe.probe_finish(hmove)
 
     def get_mcu(self):
         return self._mcu

--- a/scanner.py
+++ b/scanner.py
@@ -2380,9 +2380,8 @@ class ScannerModel:
         cur_fw = self.scanner.fw_version
         if cur_fw != self.fw_version:
             raise self.scanner.printer.command_error(
-                "Scanner model '%s' was created with firmware version %s, "
-                "current firmware version is %s. Please recalibrate the model."
-                % (self.name, self.fw_version, cur_fw)
+                f"Scanner model '{self.name}' was created with firmware version '{self.fw_version}', "
+                f"current firmware version is '{cur_fw}'. Please recalibrate the model."
             )
 
     def freq_to_dist_raw(self, freq):

--- a/scanner.py
+++ b/scanner.py
@@ -258,7 +258,6 @@ class Scanner:
                 self._mcu = self.printer.lookup_object("mcu " + mcu)
         self.cmd_queue = self._mcu.alloc_command_queue()
         self.mcu_probe = ScannerEndstopWrapper(self)
-        self.fw_version = self._mcu.get_status()["mcu_version"]
 
         self.results = []
 
@@ -1221,6 +1220,7 @@ class Scanner:
 
             self.toolhead = self.printer.lookup_object("toolhead")
             self.trapq = self.toolhead.get_trapq()
+            self.fw_version = self._mcu.get_status()["mcu_version"]
         except msgproto.error as e:
             raise msgproto.error(str(e))
 

--- a/typings/clocksync.pyi
+++ b/typings/clocksync.pyi
@@ -1,3 +1,11 @@
+from typing import final
+from reactor import Reactor
+
+@final
+class ClockSync:
+    pass
+
+@final
 class SecondarySync:
-    def __init__(self, _, __):
+    def __init__(self, reactor: Reactor, main_sync: ClockSync) -> None:
         pass

--- a/typings/configfile.pyi
+++ b/typings/configfile.pyi
@@ -11,6 +11,7 @@ class sentinel:
 
 @final
 class ConfigWrapper:
+    error = configparser.Error
     printer: Printer
     def get_printer(self) -> Printer:
         pass
@@ -165,4 +166,15 @@ class ConfigWrapper:
         count: int | None = None,
         note_valid: bool = True,
     ) -> list[float] | None:
+        pass
+
+@final
+class PrinterConfig:
+    def get_printer(self) -> Printer:
+        pass
+    def deprecate(self, option: str, value: str | None = None) -> None:
+        pass
+    def set(self, section: str, option: str, value: object) -> None:
+        pass
+    def remove_section(self, section: str) -> None:
         pass

--- a/typings/klippy.pyi
+++ b/typings/klippy.pyi
@@ -1,9 +1,12 @@
-from typing import Callable, TypeVar, final
+from typing import Callable, Literal, TypeVar, final, overload
 
-from configfile import ConfigWrapper, sentinel
 import configfile
 import gcode
+from configfile import ConfigWrapper, PrinterConfig, sentinel
+from mcu import MCU
 from reactor import Reactor
+
+from scanner import Scanner
 
 T = TypeVar("T")
 
@@ -13,10 +16,6 @@ class Printer:
     command_error = gcode.CommandError
     def add_object(self, name: str, obj: object) -> None:
         pass
-
-    def lookup_object(self, name: str, default: T | type[sentinel] = sentinel) -> T:
-        pass
-
     def load_object(
         self,
         config: ConfigWrapper,
@@ -32,4 +31,17 @@ class Printer:
     def get_reactor(self) -> Reactor:
         pass
     def register_event_handler(self, event: str, callback: Callable[[], None]) -> None:
+        pass
+
+    @overload
+    def lookup_object(self, name: Literal["configfile"]) -> PrinterConfig:
+        pass
+    @overload
+    def lookup_object(self, name: Literal["mcu"]) -> MCU:
+        pass
+    @overload
+    def lookup_object(self, name: Literal["scanner"]) -> Scanner:
+        pass
+    @overload
+    def lookup_object(self, name: str, default: T | type[sentinel] = sentinel) -> T:
         pass

--- a/typings/klippy.pyi
+++ b/typings/klippy.pyi
@@ -30,7 +30,7 @@ class Printer:
         pass
     def get_reactor(self) -> Reactor:
         pass
-    def register_event_handler(self, event: str, callback: Callable[[], None]) -> None:
+    def register_event_handler(self, event: str, callback: Callable[..., None]) -> None:
         pass
 
     @overload

--- a/typings/mcu.pyi
+++ b/typings/mcu.pyi
@@ -32,6 +32,8 @@ class MCU:
         pass
     def get_status(self) -> MCUStatus:
         pass
+    def is_fileoutput(self) -> bool:
+        pass
 
 class MCU_trsync:
     REASON_ENDSTOP_HIT = 1

--- a/typings/mcu.pyi
+++ b/typings/mcu.pyi
@@ -1,8 +1,14 @@
-from clocksync import SecondarySync
+from typing import TypedDict
+from clocksync import ClockSync, SecondarySync
+from configfile import ConfigWrapper
+
+class MCUStatus(TypedDict):
+    mcu_version: str
 
 class MCU:
-    _mcu_freq = 42
-    def __init__(self, _, sync: SecondarySync):
+    _mcu_freq: float
+    _clocksync: ClockSync
+    def __init__(self, config: ConfigWrapper, sync: SecondarySync) -> None:
         pass
     def alloc_command_queue(self):
         pass
@@ -23,6 +29,8 @@ class MCU:
     def print_time_to_clock(self, _):
         pass
     def get_printer(self):
+        pass
+    def get_status(self) -> MCUStatus:
         pass
 
 class MCU_trsync:


### PR DESCRIPTION
## Description

Requires the user to recalibrate their model if it was made with a _different_ firmware version of the probe.

![image](https://github.com/user-attachments/assets/378b7f02-cabf-4c2a-a0ef-9cc8efaf3788)
![image](https://github.com/user-attachments/assets/c9841708-1626-4914-ab8b-94786c0da8b7)


## Checklist

The following relevant macros have been tested:

- [x] `CARTOGRAPHER_CALIBRATE`
- [x] `PROBE`
- [x] `PROBE_ACCURACY`
- [x] `CARTOGRAPHER_THRESHOLD_SCAN`
- [x] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [x] `CARTOGRAPHER_TOUCH`
- [x] `CARTOGRAPHER_TOUCH METHOD=manual`
- [x] `BED_MESH_CALIBRATE`
