### PR TITLE
fix: pin python version to 3.9

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.9
           cache: "pip"
       - run: pip install -r requirements.txt
       - name: Linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.pyright]
+pythonVersion = "3.9"
 include = ["scanner.py"]
 reportMissingModuleSource = false     # klippy imports are always missing sources
 reportPrivateLocalImportUsage = false
@@ -8,4 +9,5 @@ reportUninitializedInstanceVariable = false
 failOnWarnings = false
 
 [tool.ruff]
+target-version = "py39"
 include = ["scanner.py"]

--- a/scanner.py
+++ b/scanner.py
@@ -23,7 +23,7 @@ import struct
 import threading
 import time
 import traceback
-from typing import Any, final
+from typing import Any, Optional, final
 
 import chelper
 from gcode import GCodeCommand, GCodeDispatch
@@ -1406,31 +1406,31 @@ class Scanner:
     def get_offsets(self):
         return self.offset["x"], self.offset["y"], self.trigger_distance
 
-    def get_lift_speed(self, gcmd: GCodeCommand | None = None):
+    def get_lift_speed(self, gcmd: Optional[GCodeCommand] = None):
         if gcmd is not None:
             return gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.0)
         return self.lift_speed
 
-    def get_samples(self, gcmd: GCodeCommand | None = None):
+    def get_samples(self, gcmd: Optional[GCodeCommand] = None):
         if gcmd is not None:
             return gcmd.get_int("SAMPLES", self.samples_config["samples"], minval=1)
         return self.samples_config["samples"]
 
-    def get_sample_retract_dist(self, gcmd: GCodeCommand | None = None):
+    def get_sample_retract_dist(self, gcmd: Optional[GCodeCommand] = None):
         if gcmd is not None:
             return gcmd.get_float(
                 "SAMPLE_RETRACT_DIST", self.samples_config["retract_dist"], above=0.0
             )
         return self.samples_config["retract_dist"]
 
-    def get_samples_tolerance(self, gcmd: GCodeCommand | None = None):
+    def get_samples_tolerance(self, gcmd: Optional[GCodeCommand] = None):
         if gcmd is not None:
             return gcmd.get_float(
                 "SAMPLES_TOLERANCE", self.samples_config["tolerance"], minval=0.0
             )
         return self.samples_config["retract_dist"]
 
-    def get_samples_tolerance_retries(self, gcmd: GCodeCommand | None = None):
+    def get_samples_tolerance_retries(self, gcmd: Optional[GCodeCommand] = None):
         if gcmd is not None:
             return gcmd.get_int(
                 "SAMPLES_TOLERANCE_RETRIES",
@@ -1439,7 +1439,7 @@ class Scanner:
             )
         return self.samples_config["tolerance_retries"]
 
-    def get_samples_result(self, gcmd: GCodeCommand | None = None):
+    def get_samples_result(self, gcmd: Optional[GCodeCommand] = None):
         if gcmd is not None:
             return gcmd.get("SAMPLES_RESULT", self.samples_config["result"])
         return self.samples_config["result"]
@@ -2871,7 +2871,7 @@ class ScannerWrapper:
     def get_offsets(self):
         return self.scanner.get_offsets()
 
-    def get_lift_speed(self, gcmd: GCodeCommand | None = None):
+    def get_lift_speed(self, gcmd: Optional[GCodeCommand] = None):
         return self.scanner.get_lift_speed(gcmd)
 
     def run_probe(self, gcmd: GCodeCommand):
@@ -2883,7 +2883,7 @@ class ScannerWrapper:
     def probe_finish(self, hmove):
         return self.scanner.probe_finish(hmove)
 
-    def get_probe_params(self, gcmd: GCodeCommand | None = None):
+    def get_probe_params(self, gcmd: Optional[GCodeCommand] = None):
         return {
             "probe_speed": self.scanner.probe_speed,
             "lift_speed": self.scanner.lift_speed,

--- a/typings/mcu.pyi
+++ b/typings/mcu.pyi
@@ -40,7 +40,7 @@ class MCU_trsync:
         pass
     def add_stepper(self, stepper):
         pass
-    def get_steppers(self) -> list:
+    def get_steppers(self):
         pass
     def start(self, print_time, report_offset, trigger_completion, expire_timeout):
         pass


### PR DESCRIPTION
## Description

<!--What does this PR do? Link relevant issues. What value does it bring?-->
We had an issue where we used 3.12 syntax in `scanner.py`, causing Klipper to fail on loading.
I thing 3.9 is a sane default for us.

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
