### PR TITLE
fix: tolerance is not a tuple

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -401,15 +401,13 @@ class Scanner:
             "num_samples": gcmd.get_int(
                 "SAMPLES", self.scanner_touch_config["sample_count"], minval=1
             ),
-            "tolerance": (
-                round(
-                    gcmd.get_float(
-                        "TOLERANCE",
-                        float(self.scanner_touch_config["tolerance"]),
-                        above=0.0,
-                    ),
-                    4,
+            "tolerance": round(
+                gcmd.get_float(
+                    "TOLERANCE",
+                    float(self.scanner_touch_config["tolerance"]),
+                    above=0.0,
                 ),
+                4,
             ),
             "target": gcmd.get_float(
                 "TARGET", 0.015, above=0.0


### PR DESCRIPTION
## Description

`tolerance` had become a tuple, woops.

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
