### PR TITLE
chore: add types for toolhead

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -1518,16 +1518,21 @@ class Scanner:
         toolhead = self.toolhead
         toolhead.wait_moves()
 
-        cal_min_z = cal_floor
-        cal_max_z = cal_ceil
         if manual_mode:
             nozzle_z = gcmd.get_float("NOZZLE_Z", self.cal_config["nozzle_z"])
             cal_min_z = kin_pos[2] - nozzle_z + cal_floor
             cal_max_z = kin_pos[2] - nozzle_z + cal_ceil
-        elif cal_nozzle_z is not None:
+        elif cal_nozzle_z is None:
+            raise Exception(
+                "A calculated nozzle Z position is required if not in manual mode,"
+                + " this is an error in our code."
+            )
+        else:
             curpos = toolhead.get_position()
             curpos[2] = cal_nozzle_z
             toolhead.set_position(curpos)
+            cal_min_z = cal_floor
+            cal_max_z = cal_ceil
 
         # Move to probe coordinates and compensate for backlash
         curpos = toolhead.get_position()

--- a/scanner.py
+++ b/scanner.py
@@ -557,7 +557,7 @@ class Scanner:
         try:
             self.detect_threshold_z = test_threshold
             # Set the initial position for the toolhead
-            self.toolhead.set_position(initial_position, [2])
+            self.toolhead.set_position(initial_position, homing_axes=[2])
 
             retries = 0
 
@@ -940,7 +940,7 @@ class Scanner:
         try:
             self.detect_threshold_z = test_threshold
             # Set the initial position for the toolhead
-            self.toolhead.set_position(initial_position, [2])
+            self.toolhead.set_position(initial_position, homing_axes=[2])
 
             retries = 0
             new_retry = False
@@ -1493,9 +1493,9 @@ class Scanner:
 
     def _calibrate(
         self,
-        gcmd,
+        gcmd: GCodeCommand,
         kin_pos,
-        cal_nozzle_z=None,
+        cal_nozzle_z: Optional[float] = None,
         forced_z=None,
         touch=False,
         manual_mode=False,
@@ -1518,16 +1518,16 @@ class Scanner:
         toolhead = self.toolhead
         toolhead.wait_moves()
 
+        cal_min_z = cal_floor
+        cal_max_z = cal_ceil
         if manual_mode:
             nozzle_z = gcmd.get_float("NOZZLE_Z", self.cal_config["nozzle_z"])
             cal_min_z = kin_pos[2] - nozzle_z + cal_floor
             cal_max_z = kin_pos[2] - nozzle_z + cal_ceil
-        else:
+        elif cal_nozzle_z is not None:
             curpos = toolhead.get_position()
             curpos[2] = cal_nozzle_z
             toolhead.set_position(curpos)
-            cal_min_z = cal_floor
-            cal_max_z = cal_ceil
 
         # Move to probe coordinates and compensate for backlash
         curpos = toolhead.get_position()

--- a/typings/gcode.pyi
+++ b/typings/gcode.pyi
@@ -1,5 +1,5 @@
-from typing import Callable, NamedTuple, final, overload
 # Types for https://github.com/Klipper3d/klipper/blob/master/klippy/gcode.py
+from typing import Callable, NamedTuple, final, overload
 
 @final
 class CommandError(Exception):

--- a/typings/heater.pyi
+++ b/typings/heater.pyi
@@ -1,0 +1,12 @@
+from typing import TypedDict, final
+
+class _Status(TypedDict):
+    temperature: float
+    target: float
+    power: float
+
+@final
+class Heater:
+    pass
+    def get_status(self, eventtime: float) -> _Status:
+        pass

--- a/typings/kinematics/extruder.pyi
+++ b/typings/kinematics/extruder.pyi
@@ -1,0 +1,9 @@
+from typing import final
+from heater import Heater
+
+@final
+class Extruder:
+    def get_name(self) -> str:
+        pass
+    def get_heater(self) -> Heater:
+        pass

--- a/typings/klippy.pyi
+++ b/typings/klippy.pyi
@@ -5,6 +5,7 @@ import gcode
 from configfile import ConfigWrapper, PrinterConfig, sentinel
 from mcu import MCU
 from reactor import Reactor
+from toolhead import ToolHead
 
 from scanner import Scanner
 
@@ -41,6 +42,9 @@ class Printer:
         pass
     @overload
     def lookup_object(self, name: Literal["scanner"]) -> Scanner:
+        pass
+    @overload
+    def lookup_object(self, name: Literal["toolhead"]) -> ToolHead:
         pass
     @overload
     def lookup_object(self, name: str, default: T | type[sentinel] = sentinel) -> T:

--- a/typings/toolhead.pyi
+++ b/typings/toolhead.pyi
@@ -1,0 +1,52 @@
+# Types for https://github.com/Klipper3d/klipper/blob/master/klippy/toolhead.py
+from typing import Sequence, TypedDict, final
+
+import gcode
+from kinematics.extruder import Extruder
+
+class _KinematicsStatus(TypedDict):
+    homed_axes: str
+    axis_minimum: float
+    axis_maximum: float
+
+class _Status(_KinematicsStatus):
+    print_time: float
+    stalls: int
+    estimated_print_time: float
+    extruder: str
+    position: ToolHead.Coord
+    max_velocity: float
+    max_accel: float
+    minimum_cruise_ratio: float
+    square_corner_velocity: float
+    pass
+
+type _Pos = list[float]
+
+@final
+class ToolHead:
+    Coord = gcode.Coord
+    def get_kinematics(self):
+        pass
+    def get_extruder(self) -> Extruder:
+        pass
+    def get_status(self, eventtime: float) -> _Status:
+        pass
+    def get_position(self) -> _Pos:
+        pass
+    def set_position(self, newpos: _Pos, homing_axes: Sequence[int] = ()) -> None:
+        pass
+    def move(self, newpos: _Pos, speed: float) -> None:
+        pass
+    def wait_moves(self) -> None:
+        pass
+    def dwell(self, delay: float) -> None:
+        pass
+    def flush_step_generation(self) -> None:
+        pass
+    def manual_move(self, coord: _Pos | list[float | None], speed: float) -> None:
+        pass
+    def get_trapq(self) -> str:
+        pass
+    def get_last_move_time(self) -> float:
+        pass


### PR DESCRIPTION
## Description

Just adds typing to the `lookup_object("toolhead")` call.

## Checklist

The following relevant macros have been tested:

- [x] `CARTOGRAPHER_CALIBRATE`
- [x] `PROBE`
- [x] `PROBE_ACCURACY`
- [x] `CARTOGRAPHER_THRESHOLD_SCAN`
- [x] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [x] `CARTOGRAPHER_TOUCH`
- [x] `CARTOGRAPHER_TOUCH METHOD=manual`
- [x] `BED_MESH_CALIBRATE`
