### PR TITLE
Fix fuzzy touch name

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -392,7 +392,7 @@ class Scanner:
                 "TOUCH_LOCATION_Y", float(self.touch_location[1])
             ),
             "randomize": gcmd.get_float(
-                "FUZZZY_TOUCH", self.scanner_touch_config["fuzzy_touch"], maxval=10
+                "FUZZY_TOUCH", self.scanner_touch_config["fuzzy_touch"], maxval=10
             ),
             "verbose": gcmd.get_int("DEBUG", 0),
         }


### PR DESCRIPTION
## Description

<!--What does this PR do? Link relevant issues. What value does it bring?-->

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
