### PR TITLE
[FirmwareFlasher] fix -f arg not starting at that specific menu

### DIFF
--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -2104,7 +2104,7 @@ if __name__ == "__main__":
         ## TODO ##
         ## Adjust so users cannot be in certain modes together
         Utils.make_terminal_bigger()
-        if args.all:
+        if args.all or args.flash and not args.all:
             if args.flash == FlashMethod.CAN:
                 fw.can.menu()
             elif args.flash == FlashMethod.USB:


### PR DESCRIPTION
## Description

<!--What does this PR do? Link relevant issues. What value does it bring?-->

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
