### PR TITLE
[FirmwareFlasher] Move dfu flash to advanced menu

### DIFF
--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -590,11 +590,6 @@ class Firmware:
                 + Utils.colored_text("[For Flashing via USB]", Color.YELLOW),
                 self.usb.menu,
             ),
-            3: Menu.Item(
-                "DFU               "
-                + Utils.colored_text("[For Flashing with DFU via USB]", Color.YELLOW),
-                self.dfu.menu,
-            ),
         }
 
         # Add advanced or basic options
@@ -627,6 +622,10 @@ class Firmware:
 
         if is_advanced:
             # Add advanced options
+            menu_items[len(menu_items) + 1] = Menu.Separator()
+            menu_items[len(menu_items) + 1] = Menu.Item(
+                Utils.colored_text("Flash via DFU", Color.MAGENTA), self.dfu.menu
+            )
             menu_items[len(menu_items) + 1] = Menu.Separator()
             menu_items[len(menu_items) + 1] = Menu.Item(
                 Utils.colored_text("Switch Flash Mode", Color.CYAN), self.mode_menu


### PR DESCRIPTION
## Description

<!--What does this PR do? Link relevant issues. What value does it bring?-->

## Checklist

The following relevant macros have been tested:

- [ ] `CARTOGRAPHER_CALIBRATE`
- [ ] `PROBE`
- [ ] `PROBE_ACCURACY`
- [ ] `CARTOGRAPHER_THRESHOLD_SCAN`
- [ ] `CARTOGRAPHER_TOUCH CALIBRATE=1`
- [ ] `CARTOGRAPHER_TOUCH`
- [ ] `CARTOGRAPHER_TOUCH METHOD=manual`
- [ ] `BED_MESH_CALIBRATE`
