### PR TITLE
[FirmwareFlasher] Adds Configuration file & Edit Menu + Minor Text Changes

### DIFF
--- a/scripts/firmware.cfg
+++ b/scripts/firmware.cfg
@@ -1,0 +1,4 @@
+KLIPPY_LOG = "~/printer_data/logs/klippy.log"
+KATAPULT = "~/katapult"
+KLIPPER = "~/klipper"
+KLIPPY_ENV = "~/klippy_env"

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -732,6 +732,24 @@ class Firmware:
 
         logging.debug(f"Set {config} to '{value}' in '{Utils.CONFIG_FILE}'.")
 
+    def reset_config(self) -> None:
+        """
+        Reset the configuration file to the default values.
+        """
+        try:
+            with open(Utils.CONFIG_FILE, "w") as file:
+                for key, value in Utils.DEFAULT_DIRECTORIES.items():
+                    _ = file.write(f'{key} = "{value}"\n')
+
+            self.config = dict(
+                Utils.DEFAULT_DIRECTORIES
+            )  # Reset runtime config as well
+            logging.debug(f"Reset configuration to defaults in '{Utils.CONFIG_FILE}'.")
+            Utils.success_msg("Configuration has been reset to default values.")
+        except Exception as e:
+            logging.error(f"Failed to reset configuration: {e}")
+            Utils.error_msg(f"Error resetting configuration: {e}")
+
     def restart_klipper(self):
         try:
             # Execute the restart command
@@ -918,6 +936,10 @@ class Firmware:
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Katapult",
             lambda: self.edit_config("KATAPULT"),
+        )
+        menu_items[len(menu_items) + 1] = Menu.Separator()
+        menu_items[len(menu_items) + 1] = Menu.Item(
+            "Reset to Defaults", lambda: self.reset_config()
         )
         menu_items[len(menu_items) + 1] = Menu.Separator()
         menu_items[len(menu_items) + 1] = Menu.Item(

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -935,7 +935,7 @@ class Firmware:
         )
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Katapult",
-            lambda: self.edit_config("KATAPULT"),
+            lambda: self.edit_config("KATAPULT_DIR"),
         )
         menu_items[len(menu_items) + 1] = Menu.Separator()
         menu_items[len(menu_items) + 1] = Menu.Item(

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -681,7 +681,56 @@ class Firmware:
             logging.info("No custom branch provided.")
             self.branch_menu()
 
-    def change_directory(self, directory: str): ...
+    def edit_config(self, config: str) -> None:
+        """
+        Display and allow editing of the specified config in the configuration file.
+        """
+        # Check if the config exists in the loaded config
+        if config not in self.config:
+            print(f"Config '{config}' is not a recognized configuration key.")
+            return
+
+        current_value = self.config[config]
+        print(f"Current value for '{config}': {current_value}")
+        new_value = input("Enter new value (or press Enter to keep current): ").strip()
+
+        if new_value:
+            # Update the configuration
+            self.set_config(config, new_value)
+            Utils.success_msg(f"Updated '{config}' to '{new_value}'.")
+        else:
+            Utils.success_msg(f"'{config}' unchanged.")
+        self.directory_menu()
+
+    def set_config(self, config: str, value: str) -> None:
+        """
+        Update or add a config value in the configuration file.
+        """
+        # Read current file content or initialize with defaults
+        if os.path.isfile(Utils.CONFIG_FILE):
+            with open(Utils.CONFIG_FILE, "r") as file:
+                lines = file.readlines()
+        else:
+            lines = []
+
+        # Check if the config already exists in the file
+        for i, line in enumerate(lines):
+            if line.startswith(f"{config} ="):
+                # Update the existing line
+                lines[i] = f'{config} = "{value}"\n'
+                break
+        else:
+            # Add the new config line if not found
+            lines.append(f'{config} = "{value}"\n')
+
+        # Write updated content back to the file
+        with open(Utils.CONFIG_FILE, "w") as file:
+            file.writelines(lines)
+
+        # Update the runtime config
+        self.config[config] = value
+
+        logging.debug(f"Set {config} to '{value}' in '{Utils.CONFIG_FILE}'.")
 
     def restart_klipper(self):
         try:
@@ -856,19 +905,19 @@ class Firmware:
 
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Klippy Env",
-            lambda: self.change_directory("klippy_env"),
+            lambda: self.edit_config("KLIPPY_ENV"),
         )
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Klippy Logs",
-            lambda: self.change_directory("klippy_logs"),
+            lambda: self.edit_config("KLIPPY_LOG"),
         )
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Klipper",
-            lambda: self.change_directory("klipper"),
+            lambda: self.edit_config("KLIPPER"),
         )
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Katapult",
-            lambda: self.change_directory("katapult"),
+            lambda: self.edit_config("KATAPULT"),
         )
         menu_items[len(menu_items) + 1] = Menu.Separator()
         menu_items[len(menu_items) + 1] = Menu.Item(

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -851,15 +851,16 @@ class Firmware:
         menu.display()
 
     def directory_menu(self):
+        Utils.header()
         menu_items: Dict[int, Union[Menu.Item, Menu.Separator]] = {}
 
         menu_items[len(menu_items) + 1] = Menu.Item(
-            "Printer_Data/Config",
-            lambda: self.change_directory("config"),
+            "Klippy Env",
+            lambda: self.change_directory("klippy_env"),
         )
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Klippy Logs",
-            lambda: self.change_directory("logs"),
+            lambda: self.change_directory("klippy_logs"),
         )
         menu_items[len(menu_items) + 1] = Menu.Item(
             "Klipper",


### PR DESCRIPTION
## Description

Allows users ability to edit directories for non standard installations. Includes defaults of 

- KLIPPY_LOG = ~/printer_data/logs/klippy.log
- KATAPULT_DIR = ~/katapult
- KLIPPER = ~/klipper
- KLIPPY_ENV = ~/klippy_env

File will be created and saved as firmware.cfg in the scripts folder if a user sets custom values from the menu.

![image](https://github.com/user-attachments/assets/af6233f7-ba5d-46cb-8aed-93e7a9162fd9)
![image](https://github.com/user-attachments/assets/11cb8efb-5068-4f6c-91a4-6fea0196a434)
