### PR TITLE
[FirmwareFlasher] Normalise GIT repo origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+scripts/firmware.cfg

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -28,7 +28,7 @@ from typing import (
     ClassVar,
 )
 
-FLASHER_VERSION: str = "0.0.6"
+FLASHER_VERSION: str = "0.0.4"
 
 PAGE_WIDTH: int = 89  # Default global width
 

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -28,7 +28,7 @@ from typing import (
     ClassVar,
 )
 
-FLASHER_VERSION: str = "0.0.4"
+FLASHER_VERSION: str = "0.0.6"
 
 PAGE_WIDTH: int = 89  # Default global width
 

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -2244,7 +2244,11 @@ class KatapultInstaller:
                 check=True,
             )
             origin_url = result.stdout.strip().lower()
-            if origin_url != "https://github.com/arksine/katapult".lower():
+            # Normalize URLs by removing '.git' at the end if present
+            normalized_url = origin_url.rstrip(".git")
+            expected_url = "https://github.com/arksine/katapult".rstrip(".git")
+
+            if normalized_url != expected_url:
                 Utils.error_msg(f"Unexpected repository URL: {origin_url}")
                 return False
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
As per title.

Removes .git from origin url to make sure all repos match whether they have .git or not in the url